### PR TITLE
Feat(juices): add updated_by + updatedByName; hydrate PUT

### DIFF
--- a/lib/db/schema.sql
+++ b/lib/db/schema.sql
@@ -3,5 +3,6 @@ CREATE TABLE IF NOT EXISTS juices (
   name TEXT NOT NULL,
   parLiters REAL NOT NULL,
   currentLiters REAL NOT NULL,
-  lastUpdated TEXT NOT NULL
+  lastUpdated TEXT NOT NULL,
+  updated_by INTEGER
 );

--- a/lib/repo/juices.js
+++ b/lib/repo/juices.js
@@ -3,9 +3,15 @@ export function makeJuicesRepo(db) {
   return {
     listAll() {
       return db.prepare(`
-        SELECT id, name, parLiters, currentLiters, lastUpdated
-        FROM juices
-        ORDER BY id ASC
+        SELECT j.id,
+        j.name,
+        j.parLiters,
+        j.currentLiters,
+        j.lastUpdated,
+        u.name AS updatedByName
+        FROM juices j
+        LEFT JOIN users u ON u.id = j.updated_by
+        ORDER BY j.id ASC
       `).all()
     },
 
@@ -21,12 +27,12 @@ export function makeJuicesRepo(db) {
       return db.prepare(`SELECT id FROM juices WHERE id = ?`).get(id)
     },
 
-    updateLiters(id, liters, nowISO) {
+    updateLiters(id, liters, userId, nowISO) {
       return db.prepare(`
         UPDATE juices
-           SET currentLiters = ?, lastUpdated = ?
-         WHERE id = ?
-      `).run(liters, nowISO, id)
+        SET currentLiters = ?, lastUpdated = ?, updated_by = ?
+        WHERE id = ?
+      `).run(liters, nowISO, userId, id)
     }
   }
 }

--- a/server.js
+++ b/server.js
@@ -83,6 +83,9 @@ export function createApp({ dbPath = 'db.sqlite', seed = false } = {}) {
       const updated = juices.getById(id)
       // ensure returned object matches the update exactly
       updated.lastUpdated = now
+      // HYDRATE: attach friendly updater name for immediate UI use
+      const me = db.prepare(`SELECT name FROM users WHERE id = ?`).get(userId)
+      updated.updatedByName = me?.name ?? null
       res.json(withStatus(updated))
     } catch (err) { next(err) }
   })

--- a/server.js
+++ b/server.js
@@ -42,7 +42,7 @@ export function createApp({ dbPath = 'db.sqlite', seed = false } = {}) {
   // GET /api/juices  (?sort=name|status&dir=asc|desc)
   app.get('/api/juices', (req, res, next) => {
     try {
-      const rows = db.prepare('SELECT id, name, parLiters, currentLiters, lastUpdated FROM juices').all()
+      const rows = juices.listAll()
       const enriched = rows.map(withStatus)
 
       // Read query params with defaults
@@ -77,7 +77,8 @@ export function createApp({ dbPath = 'db.sqlite', seed = false } = {}) {
       if (!exists) return notFound(res)
 
       const now = new Date().toISOString()
-      juices.updateLiters(id, liters, now)
+      const userId = req.session.userId
+      juices.updateLiters(id, liters, userId, now)
 
       const updated = juices.getById(id)
       // ensure returned object matches the update exactly

--- a/tests/juices.updated-by.spec.mjs
+++ b/tests/juices.updated-by.spec.mjs
@@ -1,0 +1,33 @@
+import { describe, it, beforeEach, expect } from 'vitest'
+import { makeApi } from './helpers.mjs'
+import { loginAs } from './auth/helpers.mjs'
+
+describe('Juices "updated by"', () => {
+  let api
+  beforeEach(async () => {
+    api = await makeApi({ seed: true })
+    await loginAs(api) // establishes a session
+  })
+
+  it('records updater on liters change and returns updatedByName in list', async () => {
+    // who am I logged in as?
+    const me = await api.get('/api/auth/me').expect(200)
+    const meName = me.body?.user?.name
+    expect(typeof meName).toBe('string')
+
+    // pick a juice
+    const listBefore = await api.get('/api/juices').expect(200)
+    const j0 = listBefore.body[0]
+
+    // update liters (even same value is fine; we stamp updated_by)
+    await api.put(`/api/juices/${j0.id}/liters`)
+      .send({ liters: j0.currentLiters })
+      .expect(200)
+
+    // fetch again and verify updatedByName
+    const listAfter = await api.get('/api/juices').expect(200)
+    const refreshed = listAfter.body.find(x => x.id === j0.id)
+    expect(refreshed).toBeTruthy()
+    expect(refreshed.updatedByName).toBe(meName)
+  })
+})

--- a/tests/juices.updated-by.spec.mjs
+++ b/tests/juices.updated-by.spec.mjs
@@ -9,7 +9,7 @@ describe('Juices "updated by"', () => {
     await loginAs(api) // establishes a session
   })
 
-  it('records updater on liters change and returns updatedByName in list', async () => {
+  it('records updater on PUT and returns updatedByName (PUT + list)', async () => {
     // who am I logged in as?
     const me = await api.get('/api/auth/me').expect(200)
     const meName = me.body?.user?.name
@@ -20,9 +20,14 @@ describe('Juices "updated by"', () => {
     const j0 = listBefore.body[0]
 
     // update liters (even same value is fine; we stamp updated_by)
-    await api.put(`/api/juices/${j0.id}/liters`)
+    const putRes = await api
+      .put(`/api/juices/${j0.id}/liters`)
       .send({ liters: j0.currentLiters })
       .expect(200)
+
+    // PUT response is hydrated
+    expect(putRes.body).toHaveProperty('updatedByName')
+    expect(putRes.body.updatedByName).toBe(meName)
 
     // fetch again and verify updatedByName
     const listAfter = await api.get('/api/juices').expect(200)


### PR DESCRIPTION
## Summary
Adds “updated by” tracking for juices and hydrates the PUT response so the UI can refresh a row without an extra GET.

## Changes
- DB: add `updated_by INTEGER` to `juices` schema.
- Repo:
  - `listAll()` LEFT JOINs `users` and returns `updatedByName`.
  - `updateLiters(id, liters, userId, nowISO)` stamps `updated_by` and `lastUpdated`.
- Routes:
  - GET /api/juices uses repo list (includes `updatedByName`).
  - PUT /api/juices/:id/liters hydrates response with `updatedByName`.
- Tests:
  - `tests/juices.updated-by.spec.mjs`: asserts `updatedByName` on PUT and GET.

## Rationale
- Hydrated PUT lets the client update the changed row immediately (no follow-up GET).
- `updatedByName` aligns response shapes across GET and PUT.

## Notes / Migration
- Schema change: requires a new DB or a simple ALTER in existing environments.
- Not live yet—wiping and reseeding is fine.
  - Local: `rm -f db.sqlite db.sqlite-shm db.sqlite-wal toastique.db && npm test`

## Validation
- [x] All tests pass locally
- [x] New e2e spec verifies updater is stamped and returned

## Follow-ups (optional)
- Show “Updated by” in the UI table if desired
- Consider `updated_at` timestamp (already using `lastUpdated`)
